### PR TITLE
Here's the plan to update the model download URLs to Zenodo:

### DIFF
--- a/fetch/utils.py
+++ b/fetch/utils.py
@@ -13,7 +13,7 @@ from tensorflow.keras.optimizers import Adam
 from tensorflow.keras.utils import get_file
 
 os.environ["HDF5_USE_FILE_LOCKING"] = "FALSE"
-PATH_TO_WEIGHTS = "http://psrpop.phys.wvu.edu/download.php?val="
+PATH_TO_WEIGHTS = "https://zenodo.org/records/5029590/files/"
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
I'll change the base URL for downloading model weights from the old WVU server to the new Zenodo record.

Specifically, I'll update the `PATH_TO_WEIGHTS` variable in `fetch/utils.py`. This will ensure the `get_model` function correctly constructs the full download URLs using this new base path and the existing filenames from `fetch/models/model_list.csv`.