### PR TITLE
Handle GlobalMaxPool

### DIFF
--- a/fetch/global_max_pool.py
+++ b/fetch/global_max_pool.py
@@ -1,0 +1,58 @@
+from typing import List
+import torch
+from torch import nn
+from onnx2torch.node_converters.registry import add_converter
+from onnx2torch.onnx_graph import OnnxGraph
+from onnx2torch.onnx_node import OnnxNode
+from onnx2torch.utils.common import (
+    OperationConverterResult,
+    get_shape_from_value_info,
+    onnx_mapping_from_node,
+)
+from onnx2torch.utils.custom_export_to_onnx import (
+    DefaultExportToOnnx,
+    OnnxToTorchModuleWithCustomExport,
+)
+
+
+class OnnxGlobalMaxPool(nn.Module, OnnxToTorchModuleWithCustomExport):
+    def forward(self, input_tensor: torch.Tensor) -> torch.Tensor:
+        def _forward():
+            x_dims = list(range(2, len(input_tensor.shape)))
+            return torch.amax(input_tensor, dim=x_dims, keepdim=True)
+
+        if torch.onnx.is_in_onnx_export():
+            return DefaultExportToOnnx.export(_forward, 'GlobalMaxPool', input_tensor, {})
+
+        return _forward()
+
+
+class OnnxGlobalMaxPoolWithKnownInputShape(nn.Module, OnnxToTorchModuleWithCustomExport):
+    def __init__(self, input_shape: List[int]):
+        super().__init__()
+        self._x_dims = list(range(2, len(input_shape)))
+
+    def forward(self, input_tensor: torch.Tensor) -> torch.Tensor:
+        def _forward() -> torch.Tensor:
+            return torch.amax(input_tensor, dim=self._x_dims, keepdim=True)
+
+        if torch.onnx.is_in_onnx_export():
+            return DefaultExportToOnnx.export(_forward, 'GlobalMaxPool', input_tensor, {})
+
+        return _forward()
+
+
+@add_converter(operation_type='GlobalMaxPool', version=1)
+def convert_global_max_pool(node: OnnxNode, graph: OnnxGraph) -> OperationConverterResult:
+    input_value_info = graph.value_info[node.input_values[0]]
+    input_shape = get_shape_from_value_info(input_value_info)
+
+    if input_shape is not None:
+        torch_module = OnnxGlobalMaxPoolWithKnownInputShape(input_shape=input_shape)
+    else:
+        torch_module = OnnxGlobalMaxPool()
+
+    return OperationConverterResult(
+        torch_module=torch_module,
+        onnx_mapping=onnx_mapping_from_node(node=node),
+    )

--- a/scripts/convert_a.py
+++ b/scripts/convert_a.py
@@ -1,0 +1,97 @@
+import argparse
+import numpy as np
+import tensorflow as tf
+import torch
+import tf2onnx
+from onnx2torch import convert
+
+from fetch import utils
+import fetch.global_max_pool  # register GlobalMaxPool converter
+
+
+def build_sample_inputs(ft_shape, dt_shape):
+    """Generate random FT and DM time inputs."""
+    ft_sample = tf.random.uniform((1,) + ft_shape)
+    dt_sample = tf.random.uniform((1,) + dt_shape)
+    return [ft_sample, dt_sample]
+
+
+def convert_keras_to_pytorch(keras_model, sample_inputs):
+    """Convert a Keras model to PyTorch using sample inputs."""
+    input_spec = [
+        tf.TensorSpec(inp.shape, dtype=inp.dtype, name=f"input{i}")
+        for i, inp in enumerate(sample_inputs)
+    ]
+    onnx_model, _ = tf2onnx.convert.from_keras(
+        keras_model, input_signature=input_spec
+    )
+    try:
+        pt_model = convert(onnx_model)
+    except NotImplementedError as e:
+        print(f"Conversion failed: {e}")
+        return None
+    pt_model.eval()
+    return pt_model
+
+
+def compare_outputs(keras_model, pt_model, sample_inputs, verbose=False):
+    """Run both models on the given inputs and return their outputs."""
+    keras_out = keras_model(sample_inputs, training=False).numpy()
+    pt_model.eval()
+    with torch.no_grad():
+        torch_inputs = [torch.from_numpy(inp.numpy()) for inp in sample_inputs]
+        pt_out = pt_model(*torch_inputs)
+    pt_out_np = pt_out.detach().cpu().numpy()
+    if verbose:
+        print("Keras output:", keras_out)
+        print("Torch output:", pt_out_np)
+    return keras_out, pt_out_np
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--model",
+        default="a",
+        help="Model index (a-k) or path to Keras .h5 model; default downloads model 'a'",
+    )
+    parser.add_argument(
+        "--examples",
+        type=int,
+        default=3,
+        help="Number of random examples to test",
+    )
+    args = parser.parse_args()
+
+    if len(args.model) == 1 and args.model.isalpha():
+        print(f"Fetching model '{args.model}' from Zenodo...")
+        keras_model = utils.get_model(args.model)
+    else:
+        print(f"Loading Keras model from {args.model}...")
+        keras_model = tf.keras.models.load_model(args.model)
+
+    input_shapes = keras_model.input_shape
+    if isinstance(input_shapes, list):
+        ft_shape = input_shapes[0][1:]
+        dt_shape = input_shapes[1][1:]
+    else:
+        ft_shape = dt_shape = input_shapes[1:]
+
+    for i in range(args.examples):
+        sample_inputs = build_sample_inputs(ft_shape, dt_shape)
+        print(
+            f"\nRunning example {i+1} with input shapes {sample_inputs[0].shape} and {sample_inputs[1].shape}..."
+        )
+        pt_model = convert_keras_to_pytorch(keras_model, sample_inputs)
+        if pt_model is None:
+            print("Skipping remaining examples due to conversion failure")
+            break
+        k_out, p_out = compare_outputs(
+            keras_model, pt_model, sample_inputs, verbose=True
+        )
+        diff = np.abs(k_out - p_out).mean()
+        print(f"Difference for example {i+1}: {diff}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- register custom GlobalMaxPool converter for onnx2torch
- remove demo model generation and default to fetching model 'a'
- keep pytorch conversion in eval mode and detach outputs before comparison

## Testing
- `pytest -q`
- `uv pip install tf2onnx onnx2torch`
- `uv run env PYTHONPATH=. python scripts/convert_a.py --examples 1` *(fails: KeyboardInterrupt during conversion)*

------
https://chatgpt.com/codex/tasks/task_b_68479b37a6548331ad5cafff2acb06b3